### PR TITLE
Add WandB saving callbacks

### DIFF
--- a/project/callbacks/__init__.py
+++ b/project/callbacks/__init__.py
@@ -4,6 +4,7 @@ from .base import LoggingCallback, QueuedLoggingCallback
 from .image import ImageLoggingCallback
 from .metric import ConfusionMatrixCallback, ErrorAtUncertaintyCallback, MetricLoggingCallback
 from .table import TableCallback
+from .wandb import WandBCheckpointCallback, WandBSaveCallback
 
 
 __all__ = [
@@ -14,4 +15,6 @@ __all__ = [
     "MetricLoggingCallback",
     "ConfusionMatrixCallback",
     "TableCallback",
+    "WandBCheckpointCallback",
+    "WandBSaveCallback",
 ]

--- a/project/callbacks/base.py
+++ b/project/callbacks/base.py
@@ -4,7 +4,7 @@
 from abc import ABC, abstractclassmethod, abstractmethod
 from functools import wraps
 from queue import PriorityQueue
-from typing import Any, Dict, Generic, Iterable, Iterator, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, ForwardRef, Generic, Iterable, Iterator, Optional, Tuple, Union
 
 import pytorch_lightning as pl
 import torch
@@ -12,8 +12,13 @@ from pytorch_lightning.callbacks import Callback
 from pytorch_lightning.utilities import rank_zero_only
 
 from ..metrics import PrioritizedItem, QueueStateCollection
-from ..model.base import BaseModel
 from ..structs import Example, I, Mode, ModeGroup, O, Prediction, State
+
+
+if TYPE_CHECKING:
+    from ..model.base import BaseModel
+else:
+    BaseModel = ForwardRef("BaseModel")
 
 
 ALL_MODES: ModeGroup = ["train", "val", "test"]
@@ -232,7 +237,7 @@ class LoggingCallback(Callback, ABC, Generic[I, O]):
         step: int,
     ):
         r"""Wrapper that calls self.log only on rank zero and when not sanity checking"""
-        assert isinstance(pl_module, BaseModel)
+        assert hasattr(pl_module, "state") and isinstance(pl_module.state, State)
         assert isinstance(tag, str) and tag
         assert isinstance(step, int) and step >= 0
         if not pl_module.state.sanity_checking:

--- a/project/callbacks/metric.py
+++ b/project/callbacks/metric.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Generic, Iterable, Union
+from typing import TYPE_CHECKING, Any, Dict, ForwardRef, Generic, Iterable, Union
 
 import pytorch_lightning as pl
 import torch
@@ -12,9 +12,14 @@ from pytorch_lightning.utilities.cli import CALLBACK_REGISTRY
 from torchmetrics import MetricCollection
 
 from ..metrics import ConfusionMatrix, ErrorAtUncertainty, MetricStateCollection
-from ..model import BaseModel
 from ..structs import I, Mode, O, State
 from .base import ALL_MODES, LoggingCallback, ModeGroup
+
+
+if TYPE_CHECKING:
+    from ..model.base import BaseModel
+else:
+    BaseModel = ForwardRef("BaseModel")
 
 
 class MetricLoggingCallback(LoggingCallback, ABC, Generic[I, O]):

--- a/project/callbacks/table.py
+++ b/project/callbacks/table.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from abc import abstractmethod
-from typing import Iterable, Optional
+from typing import TYPE_CHECKING, ForwardRef, Iterable, Optional
 
 import pandas as pd
 import pytorch_lightning as pl
@@ -11,9 +11,14 @@ import wandb
 from combustion.lightning.callbacks import DistributedDataFrame
 
 from ..metrics import DataFrameStateCollection
-from ..model import BaseModel
 from ..structs import Example, I, Mode, O, Prediction, State
 from .base import LoggingCallback, ModeGroup
+
+
+if TYPE_CHECKING:
+    from ..model.base import BaseModel
+else:
+    BaseModel = ForwardRef("BaseModel")
 
 
 class TableCallback(LoggingCallback[I, O]):

--- a/project/callbacks/wandb.py
+++ b/project/callbacks/wandb.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from pathlib import Path
+from typing import Optional, Set
+
+import pytorch_lightning as pl
+from pytorch_lightning.callbacks import Callback, ModelCheckpoint
+from pytorch_lightning.loggers import LightningLoggerBase
+from pytorch_lightning.utilities import rank_zero_only
+
+
+class WandBSaveCallback(Callback):
+    def __init__(
+        self,
+        pattern: str,
+        path: Optional[Path] = None,
+        policy: str = "end",
+    ):
+        assert policy in ("live", "now", "end")
+        self.pattern = pattern
+        self.policy = policy
+        self._path = path
+
+    @rank_zero_only
+    def save(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        for path in self.get_search_paths(trainer, pl_module):
+            assert isinstance(pl_module.logger, LightningLoggerBase)
+            pl_module.logger.experiment.save(
+                str(Path(path, "*.ckpt")),
+                policy=self.policy,
+            )
+
+    def get_search_paths(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+    ) -> Set[Path]:
+        if self._path is not None:
+            return {self._path}
+
+        assert isinstance(trainer.logger, LightningLoggerBase)
+        root = trainer.logger.save_dir or trainer.default_root_dir
+        version = (
+            trainer.logger.version if isinstance(trainer.logger.version, str) else f"version_{trainer.logger.version}"
+        )
+        path = Path(root, str(trainer.logger.name), version)
+        return {path}
+
+
+class WandBCheckpointCallback(WandBSaveCallback):
+    def __init__(
+        self,
+        pattern: str = "*.ckpt",
+        policy: str = "end",
+    ):
+        super().__init__(pattern, None, policy)
+
+    def get_search_paths(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+    ) -> Set[Path]:
+        paths: Set[Path] = set()
+        for cb in trainer.callbacks:
+            if isinstance(cb, ModelCheckpoint) and cb.dirpath:
+                paths.add(Path(cb.dirpath))
+        return paths
+
+    def on_fit_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule):
+        self.save(trainer, pl_module)
+
+    def on_exception(self, trainer: pl.Trainer, pl_module: pl.LightningModule, *_):
+        self.save(trainer, pl_module)

--- a/project/model/base.py
+++ b/project/model/base.py
@@ -3,12 +3,13 @@
 
 from abc import abstractmethod
 from functools import partial
-from typing import Any, ClassVar, Dict, Generic, Iterator, Optional, Tuple, Type, cast
+from typing import Any, ClassVar, Dict, Generic, Iterator, List, Optional, Tuple, Type, cast
 
 import matplotlib.pyplot as plt
 import pytorch_lightning as pl
 import torch
 import torch.nn.functional as F
+from pytorch_lightning.callbacks import Callback
 from pytorch_lightning.loggers import LightningLoggerBase, WandbLogger
 from pytorch_lightning.utilities import rank_zero_only
 from pytorch_lightning.utilities.cli import instantiate_class
@@ -18,6 +19,7 @@ from torchmetrics import MetricCollection
 
 from combustion.util import MISSING
 
+from ..callbacks.wandb import WandBCheckpointCallback
 from ..data import NamedDataModuleMixin
 from ..metrics import UCE, Accuracy, Entropy, MetricStateCollection
 from ..structs import Example, I, L, Loss, Mode, O, Prediction, State
@@ -294,3 +296,6 @@ class BaseModel(pl.LightningModule, Generic[I, O, L]):
         # apply the patch
         logger.experiment.log = wrapped_log
         return logger
+
+    def configure_callbacks(self) -> List[Callback]:
+        return [WandBCheckpointCallback()]

--- a/tests/test_callbacks/test_wandb.py
+++ b/tests/test_callbacks/test_wandb.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+
+import pytest
+from pytorch_lightning.callbacks import ModelCheckpoint
+
+from project.callbacks import WandBCheckpointCallback, WandBSaveCallback
+
+
+class TestWandBSaveCallback:
+    def test_get_search_paths(self, tmp_path, pl_module):
+        trainer = pl_module.trainer
+        logger = pl_module.logger
+        logger.save_dir = "save_dir"
+        logger.name = "name"
+        logger.version = "version"
+        cb = WandBSaveCallback("*.pth")
+        out = cb.get_search_paths(trainer, pl_module)
+
+        assert isinstance(out, set)
+        p = next(iter(out))
+        assert p == Path(logger.save_dir, logger.name, logger.version)
+
+
+class TestWandBCheckpointCallback:
+    @pytest.mark.parametrize("policy", ["live", "now", "end"])
+    def test_on_fit_end(self, tmp_path, pl_module, policy):
+        trainer = pl_module.trainer
+        callbacks = [
+            ModelCheckpoint(str(Path(tmp_path, "foo"))),
+            ModelCheckpoint(str(Path(tmp_path, "bar"))),
+        ]
+        patterns = set(str(Path(x.dirpath, "*.ckpt")) for x in callbacks)
+        trainer.callbacks = callbacks
+
+        cb = WandBCheckpointCallback(policy=policy)
+        cb.on_fit_end(trainer, pl_module)
+
+        exp = pl_module.logger.experiment
+        save = exp.save
+
+        assert save.call_count == len(callbacks)
+        for call in save.mock_calls:
+            assert call.args[0] in patterns
+            assert call.kwargs["policy"] == policy
+
+    @pytest.mark.parametrize("policy", ["live", "now", "end"])
+    def test_on_exception(self, tmp_path, pl_module, policy):
+        trainer = pl_module.trainer
+        callbacks = [
+            ModelCheckpoint(str(Path(tmp_path, "foo"))),
+            ModelCheckpoint(str(Path(tmp_path, "bar"))),
+        ]
+        patterns = set(str(Path(x.dirpath, "*.ckpt")) for x in callbacks)
+        trainer.callbacks = callbacks
+
+        cb = WandBCheckpointCallback(policy=policy)
+        cb.on_exception(trainer, pl_module, ...)
+
+        exp = pl_module.logger.experiment
+        save = exp.save
+
+        assert save.call_count == len(callbacks)
+        for call in save.mock_calls:
+            assert call.args[0] in patterns
+            assert call.kwargs["policy"] == policy


### PR DESCRIPTION
Resolves #15. WandB creates a symlink to the most recent run. This change calls `wandb.save` on checkpoint files, making them available in the generated symlink path and uploading them to WandB.